### PR TITLE
Feature: onboard subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Status of connector | `bool` | `true` | no |
 | <a name="input_group"></a> [group](#input\_group) | Group to associate with connector | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of connector | `string` | n/a | yes |
+| <a name="input_onboard_subnet"></a> [onboard\_subnet](#input\_onboard\_subnet) | Controls if subnet gets onboarded in place of entire VPC CIDR block | `bool` | `false` | no |
 | <a name="input_segment"></a> [segment](#input\_segment) | Segment to provision connector in | `string` | n/a | yes |
 | <a name="input_size"></a> [size](#input\_size) | Size of connector | `string` | `"SMALL"` | no |
-| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR of AWS VPC that is being connected | `list(string)` | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Onboard specific subnets in place of entire VPC CIDR block | <pre>list(object({<br>    cidr  = optional(string)<br>    id    = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR of AWS VPC that is being connected | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of AWS VPC that is being connected | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,19 @@ resource "alkira_connector_aws_vpc" "connector" {
   segment_id       = data.alkira_segment.segment.id
   size             = var.size
   vpc_id           = var.vpc_id
-  vpc_cidr         = var.vpc_cidr
+  vpc_cidr         = var.onboard_subnet ? null : var.vpc_cidr
+
+  # If bool == true, onboard custom subnets in place of entire VPC CIDR block
+  dynamic "vpc_subnet" {
+    for_each = {
+      for o in var.subnets : o.id => o
+      if var.onboard_subnet == true
+    }
+
+    content {
+      cidr = vpc_subnet.value.cidr
+      id   = vpc_subnet.value.id
+    }
+  }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,9 +42,25 @@ variable "name" {
   type         = string
 }
 
+variable "onboard_subnet" {
+  description = "Controls if subnet gets onboarded in place of entire VPC CIDR block"
+  type        = bool
+  default     = false
+}
+
 variable "segment" {
   description  = "Segment to provision connector in"
   type         = string
+}
+
+variable "subnets" {
+  description = "Onboard specific subnets in place of entire VPC CIDR block"
+
+  type = list(object({
+    cidr  = optional(string)
+    id    = optional(string)
+  }))
+  default = []
 }
 
 variable "size" {
@@ -61,4 +77,5 @@ variable "vpc_id" {
 variable "vpc_cidr" {
   description  = "CIDR of AWS VPC that is being connected"
   type         = list(string)
+  default      = []
 }


### PR DESCRIPTION
## Overview
Add the ability to onboard specific subnets in place of the entire VPC CIDR block.

```hcl
subnets   = [
    {
      cidr  = "10.150.1.0/24"
      id     = "subnet-12345"
    },
    {
      cidr  = "10.150.2.0/24"
      id     = "subnet-6789"
    }
  ]
```