### PR TITLE
Feature: custom routing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Alkira AWS Connector
-Terraform module that provisions [Alkira AWS Connector](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/connector_aws_vpc). This can be used along with [AWS VPC Terraform module](https://github.com/terraform-aws-modules/terraform-aws-vpc) to handle the workflow _end-to-end_. This module is currently in _beta_.
+Terraform module that provisions [Alkira AWS Connector](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/connector_aws_vpc). This can be used along with [AWS VPC Terraform module](https://github.com/terraform-aws-modules/terraform-aws-vpc) to handle the complete VPC _lifecycle_. This module is currently in _beta_.
 
 ## Basic Usage
 ```hcl

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 # Alkira AWS Connector
 Terraform module that provisions [Alkira AWS Connector](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/connector_aws_vpc). This can be used along with [AWS VPC Terraform module](https://github.com/terraform-aws-modules/terraform-aws-vpc) to handle the workflow _end-to-end_. This module is currently in _beta_.
 
+## Basic Usage
+```hcl
+module "create_vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "vpc-east-dev"
+  cidr = "10.150.0.0/20"
+
+  azs             = ["us-east-2b", "us-east-2c"]
+  private_subnets = ["10.150.1.0/24", "10.150.2.0/24"]
+
+  tags = {
+    Terraform = "true"
+    Environment = "dev"
+  }
+
+}
+
+module "connect_vpc" {
+  source = "alkiranet/connector-aws/alkira"
+
+  name              = "connector-east-dev"
+  cxp               = "US-EAST-2"
+  credential        = "aws-credential"
+  segment           = "business"
+  group             = "cloud"
+  aws_account_id    = "123456789"
+  aws_region        = "us-east-2"
+  vpc_cidr          = [module.create_vpc.vpc_cidr_block]
+  vpc_id            = module.create_vpc.vpc_id
+
+  depends_on = [module.create_vpc]
+
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No modules.
 | [alkira_billing_tag.tag](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/billing_tag) | data source |
 | [alkira_credential.credential](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/credential) | data source |
 | [alkira_group.group](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/group) | data source |
+| [alkira_policy_prefix_list.prefix](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/policy_prefix_list) | data source |
 | [alkira_segment.segment](https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/data-sources/segment) | data source |
 
 ## Inputs
@@ -37,14 +38,21 @@ No modules.
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region of the VPC being connected | `string` | n/a | yes |
 | <a name="input_billing_tags"></a> [billing\_tags](#input\_billing\_tags) | Billing tags associated with connector | `list(string)` | `[]` | no |
 | <a name="input_credential"></a> [credential](#input\_credential) | Name of credential to use for onboarding VPC | `string` | n/a | yes |
+| <a name="input_custom_routing"></a> [custom\_routing](#input\_custom\_routing) | Controls if custom routing is used from cloud network to CXP | `bool` | `false` | no |
+| <a name="input_custom_tgw"></a> [custom\_tgw](#input\_custom\_tgw) | Controls if specific subnets are used for linked availability zones | `bool` | `false` | no |
 | <a name="input_cxp"></a> [cxp](#input\_cxp) | CXP to provision connector in | `string` | n/a | yes |
+| <a name="input_direct_inter_vpc"></a> [direct\_inter\_vpc](#input\_direct\_inter\_vpc) | Enable direct inter-vpc communication | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Status of connector | `bool` | `true` | no |
+| <a name="input_failover_cxps"></a> [failover\_cxps](#input\_failover\_cxps) | Enable direct inter-vpc communication | `list(string)` | `[]` | no |
 | <a name="input_group"></a> [group](#input\_group) | Group to associate with connector | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of connector | `string` | n/a | yes |
 | <a name="input_onboard_subnet"></a> [onboard\_subnet](#input\_onboard\_subnet) | Controls if subnet gets onboarded in place of entire VPC CIDR block | `bool` | `false` | no |
+| <a name="input_route_table_id"></a> [route\_table\_id](#input\_route\_table\_id) | ID of VPC default route table | `string` | `""` | no |
+| <a name="input_routing_options"></a> [routing\_options](#input\_routing\_options) | Custom routing options used to influence routing from cloud network to CXP | <pre>list(object({<br>    prefix_lists    = optional(list(string))<br>    route_option    = optional(string)<br>    route_table_id  = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_segment"></a> [segment](#input\_segment) | Segment to provision connector in | `string` | n/a | yes |
 | <a name="input_size"></a> [size](#input\_size) | Size of connector | `string` | `"SMALL"` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | Onboard specific subnets in place of entire VPC CIDR block | <pre>list(object({<br>    cidr  = optional(string)<br>    id    = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | Subnets to onboard in place of entire VPC CIDR block | <pre>list(object({<br>    subnet_id    = optional(string)<br>    subnet_cidr  = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_tgw_attachment"></a> [tgw\_attachment](#input\_tgw\_attachment) | Subnets to use for linked availability zones | <pre>list(object({<br>    az         = optional(string)<br>    subnet_id  = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR of AWS VPC that is being connected | `list(string)` | `[]` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of AWS VPC that is being connected | `string` | n/a | yes |
 

--- a/README.md
+++ b/README.md
@@ -36,20 +36,19 @@ module "connect_vpc" {
 
 }
 ```
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.9.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_alkira"></a> [alkira](#requirement\_alkira) | >= 0.9.7 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.9.2 |
+| <a name="provider_alkira"></a> [alkira](#provider\_alkira) | >= 0.9.7 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -61,4 +61,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_connector_id"></a> [connector\_id](#output\_connector\_id) | ID of connector |
+| <a name="output_implicit_group_id"></a> [implicit\_group\_id](#output\_implicit\_group\_id) | ID of implicit group automatically created with connector |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ resource "alkira_connector_aws_vpc" "connector" {
   cxp                             = var.cxp
   direct_inter_vpc_communication  = var.direct_inter_vpc
   enabled                         = var.enabled
+  failover_cxps                   = var.failover_cxps
   group                           = data.alkira_group.group.name
   name                            = var.name
   segment_id                      = data.alkira_segment.segment.id

--- a/main.tf
+++ b/main.tf
@@ -15,13 +15,40 @@ data "alkira_group" "group" {
   name = var.group
 }
 
+data "alkira_policy_prefix_list" "prefix" {
+  for_each = {
+    for k, v in toset(local.filter_custom_prefixes) : k => v
+    if var.custom_routing == true
+  }
+  name     = each.key
+}
+
 data "alkira_segment" "segment" {
   name = var.segment
 }
 
 locals {
 
-  # filter ids
+  filter_custom_prefixes = flatten([
+    for rtb in var.routing_options : [
+      for pfx in rtb.prefix_lists : 
+        pfx
+    ]
+  ])
+
+  pfx_id_list = [
+    for v in data.alkira_policy_prefix_list.prefix : v.id
+  ]
+
+  filter_routing_options = flatten([
+    for r in var.routing_options : {
+      id               = r.route_table_id
+      options          = r.route_option
+      prefix_list_ids  = [for pfx in r.prefix_lists : lookup(data.alkira_policy_prefix_list.prefix, pfx, null).id]
+    }
+  ])
+
+  # filter tag ids
   tag_id_list = [
     for v in data.alkira_billing_tag.tag : v.id
   ]
@@ -35,29 +62,57 @@ https://registry.terraform.io/providers/alkiranet/alkira/latest/docs/resources/c
 resource "alkira_connector_aws_vpc" "connector" {
 
   # Connector values
-  aws_account_id   = var.aws_account_id
-  aws_region       = var.aws_region
-  billing_tag_ids  = local.tag_id_list
-  credential_id    = data.alkira_credential.credential.id
-  cxp              = var.cxp
-  enabled          = var.enabled
-  group            = data.alkira_group.group.name
-  name             = var.name
-  segment_id       = data.alkira_segment.segment.id
-  size             = var.size
-  vpc_id           = var.vpc_id
-  vpc_cidr         = var.onboard_subnet ? null : var.vpc_cidr
+  aws_account_id                  = var.aws_account_id
+  aws_region                      = var.aws_region
+  billing_tag_ids                 = local.tag_id_list
+  credential_id                   = data.alkira_credential.credential.id
+  cxp                             = var.cxp
+  direct_inter_vpc_communication  = var.direct_inter_vpc
+  enabled                         = var.enabled
+  group                           = data.alkira_group.group.name
+  name                            = var.name
+  segment_id                      = data.alkira_segment.segment.id
+  size                            = var.size
+  vpc_id                          = var.vpc_id
+  vpc_cidr                        = var.onboard_subnet ? null : var.vpc_cidr
+
+  # If bool == true, use custom subnet for linked availability zones
+  dynamic "tgw_attachment" {
+    for_each = {
+      for o in var.tgw_attachment : o.subnet_id => o
+      if var.custom_tgw == true
+    }
+
+    content {
+      az         = tgw_attachment.value.az
+      subnet_id  = tgw_attachment.value.subnet_id
+    }
+  }
 
   # If bool == true, onboard custom subnets in place of entire VPC CIDR block
   dynamic "vpc_subnet" {
     for_each = {
-      for o in var.subnets : o.id => o
+      for o in var.subnets : o.subnet_id => o
       if var.onboard_subnet == true
     }
 
     content {
-      cidr = vpc_subnet.value.cidr
-      id   = vpc_subnet.value.id
+      id   = vpc_subnet.value.subnet_id
+      cidr = vpc_subnet.value.subnet_cidr
+    }
+  }
+
+  # If bool == true, use custom routing options
+  dynamic "vpc_route_table" {
+    for_each = {
+      for o in local.filter_routing_options : o.id => o
+      if var.custom_routing == true
+    }
+
+    content {
+      id              = vpc_route_table.value.id
+      options         = vpc_route_table.value.options
+      prefix_list_ids = vpc_route_table.value.prefix_list_ids
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,6 @@ locals {
     }
   ])
 
-  # filter tag ids
   tag_id_list = [
     for v in data.alkira_billing_tag.tag : v.id
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "connector_id" {
   description = "ID of connector"
   value       = alkira_connector_aws_vpc.connector.id
 }
+
+output "implicit_group_id" {
+  description = "ID of implicit group automatically created with connector"
+  value       = alkira_connector_aws_vpc.connector.implicit_group_id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -20,9 +20,33 @@ variable "credential" {
   type         = string
 }
 
+variable "custom_routing" {
+  description  = "Controls if custom routing is used from cloud network to CXP"
+  type         = bool
+  default      = false
+}
+
+variable "custom_tgw" {
+  description  = "Controls if specific subnets are used for linked availability zones"
+  type         = bool
+  default      = false
+}
+
 variable "cxp" {
   description  = "CXP to provision connector in"
   type         = string
+}
+
+variable "direct_inter_vpc" {
+  description = "Enable direct inter-vpc communication"
+  type        = bool
+  default     = false
+}
+
+variable "route_table_id" {
+  description  = "ID of VPC default route table"
+  type         = string
+  default      = ""
 }
 
 variable "enabled" {
@@ -48,17 +72,28 @@ variable "onboard_subnet" {
   default     = false
 }
 
+variable "routing_options" {
+  description = "Custom routing options used to influence routing from cloud network to CXP"
+
+  type = list(object({
+    prefix_lists    = optional(list(string))
+    route_option    = optional(string)
+    route_table_id  = optional(string)
+  }))
+  default = []
+}
+
 variable "segment" {
   description  = "Segment to provision connector in"
   type         = string
 }
 
 variable "subnets" {
-  description = "Onboard specific subnets in place of entire VPC CIDR block"
+  description = "Subnets to onboard in place of entire VPC CIDR block"
 
   type = list(object({
-    cidr  = optional(string)
-    id    = optional(string)
+    subnet_id    = optional(string)
+    subnet_cidr  = optional(string)
   }))
   default = []
 }
@@ -68,6 +103,17 @@ variable "size" {
   type         = string
   default      = "SMALL"
 }
+
+variable "tgw_attachment" {
+  description = "Subnets to use for linked availability zones"
+
+  type = list(object({
+    az         = optional(string)
+    subnet_id  = optional(string)
+  }))
+  default = []
+}
+
 
 variable "vpc_id" {
   description  = "ID of AWS VPC that is being connected"

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,12 @@ variable "direct_inter_vpc" {
   default     = false
 }
 
+variable "failover_cxps" {
+  description = "Enable direct inter-vpc communication"
+  type        = list(string)
+  default     = []
+}
+
 variable "route_table_id" {
   description  = "ID of VPC default route table"
   type         = string

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,11 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
 
     alkira = {
       source  = "alkiranet/alkira"
-      version = ">= 0.9.2"
+      version = ">= 0.9.7"
     }
 
   }


### PR DESCRIPTION
## Overview
Integrated options for _direct_inter_vpc_communication_ and _failover_cxps_ along with:

### Custom Routing Options

```hcl
  routing_options = [
    {
      prefix_lists        = ["dc11"]
      route_option     = "ADVERTISE_CUSTOM_PREFIX"
      route_table_id  = "rtb-01234"
    },
    {
      prefix_lists       = ["dc3"]
      route_option    = "ADVERTISE_CUSTOM_PREFIX"
      route_table_id  = "rtb-56789"
    }
  ]
```

### TGW Attachment Configuration

```hcl
tgw_attachment = [
    {
      az               = "us-east-2b"
      subnet_id  = "subnet-01234"
    },
    {
      az               = "us-east-2c"
      subnet_id  = "subnet-56789"
    }
  ]
```